### PR TITLE
Add command to clear chef-client cache after run

### DIFF
--- a/providers/foodtruck-provider-infra
+++ b/providers/foodtruck-provider-infra
@@ -40,4 +40,7 @@ cd out
 echo Running chef-client "${chef_client_args[@]}"
 eval ${chef_client_args[*]}
 
+echo "Cleaning up chef-client cache"
+rm -rf /var/chef/cache
+
 exit 0


### PR DESCRIPTION
Signed-off-by: Jon Cowie <jonlives@gmail.com>

Adds a command to the infra provider to clear the client cache after performing a run